### PR TITLE
Fix JSON parser when the value of the 'criticality' field is null

### DIFF
--- a/rdjson_formatter.rb
+++ b/rdjson_formatter.rb
@@ -4,6 +4,7 @@ require 'json'
 GEMFILE_LOCK_PATH = "Gemfile.lock"
 
 CRITICALITY_RANK = {
+  unknown: 0,
   none: 0,
   low: 1,
   medium: 2,
@@ -26,7 +27,8 @@ diagnostics = results.map do |result|
     Solution: upgrade to #{result.dig("advisory", "patched_versions").map{|v| "'#{v}'"}.join(', ')}
   EOS
 
-  criticality_rank = CRITICALITY_RANK[result.dig("advisory", "criticality").to_sym]
+  criticality = result.dig("advisory", "criticality") || :unknown
+  criticality_rank = CRITICALITY_RANK[criticality.to_sym]
   max_criticality_rank = [max_criticality_rank, criticality_rank].max 
 
   line = `grep -n -E '^\s{4}#{gem_name}' #{GEMFILE_LOCK_PATH} | cut -d : -f 1`.to_i


### PR DESCRIPTION
When there is no CVSS score for a finding, the value of the `criticality` field in the JSON output of `bundler-audit` is `null`. This causes `result.dig("advisory", "criticality").to_sym` to give the following error:
```ruby
undefined method `to_sym' for nil:NilClass (NoMethodError)
```

The term `unknown` is used to be in line with `bundler-audit`'s criticality labels: https://github.com/rubysec/bundler-audit/blob/1c9ece212370f937dae9491452b4da6647f39667/lib/bundler/audit/cli/formats/json.rb#L49-L58