### PR TITLE
Handle missing criticality

### DIFF
--- a/rdjson_formatter.rb
+++ b/rdjson_formatter.rb
@@ -9,6 +9,7 @@ CRITICALITY_RANK = {
   medium: 2,
   high: 3,
   critical: 3,
+  nil => 1,
 }
 
 SEVERITY = ["UNKNOWN_SEVERITY", "INFO", "WARNING", "ERROR"]
@@ -26,7 +27,7 @@ diagnostics = results.map do |result|
     Solution: upgrade to #{result.dig("advisory", "patched_versions").map{|v| "'#{v}'"}.join(', ')}
   EOS
 
-  criticality_rank = CRITICALITY_RANK[result.dig("advisory", "criticality").to_sym]
+  criticality_rank = CRITICALITY_RANK[result.dig("advisory", "criticality")&.to_sym]
   max_criticality_rank = [max_criticality_rank, criticality_rank].max 
 
   line = `grep -n -E '^\s{4}#{gem_name}' #{GEMFILE_LOCK_PATH} | cut -d : -f 1`.to_i


### PR DESCRIPTION
Sometimes an advisory does not have a criticality, in which case the value will be `nil`. This is documented in the [bundler-audit code](https://github.com/rubysec/bundler-audit/blob/bc041d13eeccab70dd01672c097e8906108d07e3/lib/bundler/audit/advisory.rb#L135).

This value, however, will yield the following error:

```
rdjson_formatter.rb:29:in `block in <main>': undefined method `to_sym' for nil:NilClass (NoMethodError)

  criticality_rank = CRITICALITY_RANK[result.dig("advisory", "criticality").to_sym]
                                                                           ^^^^^^^
	from rdjson_formatter.rb:21:in `map'
	from rdjson_formatter.rb:21:in `<main>'
```

This PR allows for a missing criticality and defaults it to `low`.

Example advisory without a criticality:

```json
{
  "version": "0.9.1",
  "created_at": "2023-06-27 17:09:29 +0200",
  "results": [
    {
      "type": "unpatched_gem",
      "gem": {
        "name": "actionpack",
        "version": "7.0.4.3"
      },
      "advisory": {
        "path": "/.../ruby-advisory-db/gems/actionpack/CVE-2023-28362.yml",
        "id": "CVE-2023-28362",
        "url": "https://discuss.rubyonrails.org/t/cve-2023-28362-possible-xss-via-user-supplied-values-to-redirect-to/83132",
        "title": "Possible XSS via User Supplied Values to redirect_to",
        "date": "2023-06-26",
        "description": "The redirect_to method in Rails allows provided values to contain characters\nwhich are not legal in an HTTP header value. This results in the potential for\ndownstream services which enforce RFC compliance on HTTP response headers to\nremove the assigned Location header. This vulnerability has been assigned the\nCVE identifier CVE-2023-28362.\n\nVersions Affected: All. Not affected: None Fixed Versions: 7.0.5.1, 6.1.7.4\n\n# Impact\n\nThis introduces the potential for a Cross-site-scripting (XSS) payload to be\ndelivered on the now static redirection page. Note that this both requires\nuser interaction and for a Rails app to be configured to allow redirects to\nexternal hosts (defaults to false in Rails >= 7.0.x).\n\n# Releases\n\nThe FIXED releases are available at the normal locations.\n\n# Workarounds\n\nAvoid providing user supplied URLs with arbitrary schemes to the redirect_to\nmethod.\n",
        "cvss_v2": null,
        "cvss_v3": null,
        "cve": "2023-28362",
        "osvdb": null,
        "ghsa": null,
        "unaffected_versions": [

        ],
        "patched_versions": [
          "~> 6.1.7.4",
          ">= 7.0.5.1"
        ],
        "criticality": null
      }
    }
  ]
}
```
